### PR TITLE
Fixed issue with mixed usage of argument vs arguement (both technical…

### DIFF
--- a/GovNotifyMMF.py
+++ b/GovNotifyMMF.py
@@ -112,14 +112,14 @@ class MemoryMappedFile_IPC:
         func = func.replace(">", "")
         func = func.replace("|", "")
 
-        argument = arguement.replace("<", "less than")
-        argument = arguement.replace(">", "more than")
-        argument = arguement.replace("|", "pipe")
+        arguement = arguement.replace("<", "less than")
+        arguement = arguement.replace(">", "more than")
+        arguement = arguement.replace("|", "pipe")
         
-        if argument == "":
+        if arguement == "":
             buffer = "<" + func + ">"
         else:
-            buffer = "<" + func + SEPARATOR + argument + ">"
+            buffer = "<" + func + SEPARATOR + arguement + ">"
         
         self.MMFInstance.seek(0) #Move back to beginning of file
         self.MMFInstance.write(bytes(buffer, 'UTF-8'))


### PR DESCRIPTION
Fixed issue in MemoryMappedFile_IPC write method with mixed usage of argument vs arguement (both technically fine spellings), but it meant that the (<>|) replacements would not have worked as intended